### PR TITLE
feat(api): persist clock-in to Postgres via Prisma

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AttendanceController } from './attendance.controller';
+import { AttendanceService } from './attendance.service';
+import { PrismaModule } from './prisma.module';
 
 @Module({
-  imports: [],
-  controllers: [AppController, AttendanceController], // ← ここに登録されていること
-  providers: [],
+  imports: [PrismaModule],
+  controllers: [AppController, AttendanceController],
+  providers: [AttendanceService],
 })
 export class AppModule {}

--- a/apps/api/src/attendance.controller.ts
+++ b/apps/api/src/attendance.controller.ts
@@ -1,15 +1,13 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { ClockInDto } from './dto/clock-in.dto';
+import { AttendanceService } from './attendance.service';
 
 @Controller('attendance')
 export class AttendanceController {
+  constructor(private readonly attendanceService: AttendanceService) {}
+
   @Post('clock-in')
-  clockIn(@Body() body: ClockInDto) {
-    const now = new Date().toISOString();
-    return {
-      userId: body.userId,
-      clockInAt: now, // 後でDBに入れる想定
-      message: `User ${body.userId} clocked in.`,
-    };
+  async clockIn(@Body() body: ClockInDto) {
+    return this.attendanceService.clockIn(body.userId);
   }
 }

--- a/apps/api/src/attendance.service.ts
+++ b/apps/api/src/attendance.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Injectable()
+export class AttendanceService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async clockIn(userId: string) {
+    const now = new Date();
+    const record = await this.prisma.attendance.create({
+      data: {
+        userId,
+        startedAt: now,
+        status: 'WORKING',
+      },
+    });
+
+    return {
+      id: record.id,
+      userId: record.userId,
+      clockInAt: record.startedAt,
+      message: `User ${record.userId} clocked in.`,
+    };
+  }
+}

--- a/apps/api/src/prisma.module.ts
+++ b/apps/api/src/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/apps/api/src/prisma.service.ts
+++ b/apps/api/src/prisma.service.ts
@@ -1,0 +1,15 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}


### PR DESCRIPTION
## 概要
- `POST /attendance/clock-in` を Prisma 経由で DB 永続化
- PrismaService / PrismaModule を追加し、Attendance に `userId` と `startedAt` を保存
- レスポンスを `{ id, userId, clockInAt, message }` に整形

## 動作確認
1. `docker compose up -d` で DB 起動
2. `pnpm dev` を実行
3. `Invoke-RestMethod` で `{"userId":"u001"}` を POST
4. 200 で JSON が返り、Prisma Studio でレコード作成を確認

## 次の改善案
- 二重打刻を防ぐバリデーション（未終了レコードがある場合は 409 を返す）
- 表示時に JST へ変換