### PR TITLE
feat(attendance): add workedMinutes to clock-out API and improve web …

### DIFF
--- a/apps/api/src/attendance.service.ts
+++ b/apps/api/src/attendance.service.ts
@@ -48,10 +48,7 @@ export class AttendanceService {
     const end = new Date();
     const updated = await this.prisma.attendance.update({
       where: { id: open.id },
-      data: {
-        endedAt: end,
-        status: 'OFF',
-      },
+      data: { endedAt: end, status: 'OFF' },
       select: {
         id: true,
         userId: true,
@@ -61,12 +58,20 @@ export class AttendanceService {
       },
     });
 
+    // 実働 = (終了 - 開始) - 休憩（分）
+    const totalMinutes = Math.max(
+      0,
+      Math.ceil((updated.endedAt!.getTime() - updated.startedAt.getTime()) / 60_000),
+    );
+    const workedMinutes = Math.max(0, totalMinutes - updated.breakMinutes);
+
     return {
       id: updated.id,
       userId: updated.userId,
       clockInAt: updated.startedAt,
       clockOutAt: updated.endedAt,
       breakMinutes: updated.breakMinutes,
+      workedMinutes, // ★ 追加
       message: `User ${updated.userId} clocked out.`,
     };
   }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,17 +3,31 @@
 import { useState } from 'react';
 
 export default function Page() {
+  const [userId, setUserId] = useState<string>('u001');
+
   const [clockInResult, setClockInResult] = useState<string>('');
   const [clockOutResult, setClockOutResult] = useState<string>('');
   const [breakStartResult, setBreakStartResult] = useState<string>('');
   const [breakEndResult, setBreakEndResult] = useState<string>('');
+
+  const fmtJST = (iso?: string) => {
+    if (!iso) return '';
+    return new Intl.DateTimeFormat('ja-JP', {
+      timeZone: 'Asia/Tokyo',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(iso));
+  };
 
   const clockIn = async () => {
     try {
       const res = await fetch('http://localhost:3001/attendance/clock-in', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: 'u001' }),
+        body: JSON.stringify({ userId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
@@ -28,11 +42,15 @@ export default function Page() {
       const res = await fetch('http://localhost:3001/attendance/clock-out', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: 'u001' }),
+        body: JSON.stringify({ userId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
-      setClockOutResult(JSON.stringify(json));
+      // 例: "09/01 18:05 → 09/01 19:10 / 実働65分（休憩10分）"
+      const nice =
+        `${fmtJST(json.clockInAt)} → ${fmtJST(json.clockOutAt)} / ` +
+        `実働${json.workedMinutes ?? '?'}分（休憩${json.breakMinutes ?? '?'}分）`;
+      setClockOutResult(nice);
     } catch (e) {
       setClockOutResult(`error: ${(e as Error).message}`);
     }
@@ -43,7 +61,7 @@ export default function Page() {
       const res = await fetch('http://localhost:3001/attendance/break-start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: 'u001' }),
+        body: JSON.stringify({ userId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
@@ -58,7 +76,7 @@ export default function Page() {
       const res = await fetch('http://localhost:3001/attendance/break-end', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: 'u001' }),
+        body: JSON.stringify({ userId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
@@ -72,20 +90,23 @@ export default function Page() {
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
       <h1 className="text-4xl font-bold mb-8">Hi!</h1>
 
+      {/* userId 入力 */}
+      <div className="mb-6 flex items-center gap-2">
+        <label className="text-sm text-gray-600">userId:</label>
+        <input
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          className="px-2 py-1 border rounded"
+          placeholder="u001"
+        />
+      </div>
+
       {/* 出勤打刻 */}
-      <div className="mt-4 flex items-center gap-4">
+      <div className="mt-2 flex items-center gap-4">
         <button onClick={clockIn} className="px-4 py-2 rounded border hover:bg-gray-50">
           出勤打刻 (API)
         </button>
         <span className="text-sm text-gray-600">clock-in: {clockInResult}</span>
-      </div>
-
-      {/* 退勤打刻 */}
-      <div className="mt-6 flex items-center gap-4">
-        <button onClick={clockOut} className="px-4 py-2 rounded border hover:bg-gray-50">
-          退勤打刻 (API)
-        </button>
-        <span className="text-sm text-gray-600">clock-out: {clockOutResult}</span>
       </div>
 
       {/* 休憩開始 */}
@@ -102,6 +123,14 @@ export default function Page() {
           休憩終了 (API)
         </button>
         <span className="text-sm text-gray-600">break-end: {breakEndResult}</span>
+      </div>
+
+      {/* 退勤打刻 */}
+      <div className="mt-6 flex items-center gap-4">
+        <button onClick={clockOut} className="px-4 py-2 rounded border hover:bg-gray-50">
+          退勤打刻 (API)
+        </button>
+        <span className="text-sm text-gray-600">clock-out: {clockOutResult}</span>
       </div>
     </main>
   );


### PR DESCRIPTION
…UI (JST display, userId input)
## 概要
- 退勤 API (`POST /attendance/clock-out`)
  - 実働分 `workedMinutes` をレスポンスに追加
  - 総時間の計算を **ceil（切り上げ）** に変更し、端数秒のズレを解消
- Web UI (`apps/web/app/page.tsx`)
  - userId 入力欄を追加（固定値 u001 → 任意入力）
  - 退勤結果を JST で表示（年月日・時刻）
  - 実働分・休憩分を見やすい形で出力

## 変更内容
- `apps/api/src/attendance.service.ts`
  - `clockOut` 内の計算式を修正
  - `workedMinutes` をレスポンスに含めるように変更
- `apps/web/app/page.tsx`
  - userId 入力欄を追加
  - JST 表示フォーマッタを実装
  - 退勤結果表示を改善

## 動作確認
1. 出勤 → 休憩開始 → 休憩終了 → 退勤
2. レスポンスに `workedMinutes` が含まれ、休憩時間を差し引いた分数が正しく算出される
3. 秒単位の端数があるケースでも「表示される時刻 - 休憩分」と一致
4. Web 側で userId を変更して打刻できることを確認

## 影響範囲
- 退勤 API のレスポンスフォーマットに `workedMinutes` が追加
- フロント表示が改善（既存動作は維持）
- DB スキーマ変更なし
